### PR TITLE
feat: 패스키 등록 시 개인정보 수집 동의하도록 변경

### DIFF
--- a/src/main/java/com/sign/application/repository/PersonalInfoAgreeRepository.java
+++ b/src/main/java/com/sign/application/repository/PersonalInfoAgreeRepository.java
@@ -1,0 +1,5 @@
+package com.sign.application.repository;
+
+public interface PersonalInfoAgreeRepository {
+    void save(String email, boolean agree);
+}

--- a/src/main/java/com/sign/application/usecase/PasskeyRegistrationUseCase.java
+++ b/src/main/java/com/sign/application/usecase/PasskeyRegistrationUseCase.java
@@ -2,6 +2,7 @@ package com.sign.application.usecase;
 
 import com.sign.application.repository.HandleGenerator;
 import com.sign.application.repository.PasskeyRepository;
+import com.sign.application.repository.PersonalInfoAgreeRepository;
 import com.sign.domain.EmailValidator;
 import com.sign.dto.PasskeyRegistrationRequest;
 import com.sign.dto.PasskeyRegistrationResult;
@@ -9,14 +10,7 @@ import com.yubico.webauthn.FinishRegistrationOptions;
 import com.yubico.webauthn.RegisteredCredential;
 import com.yubico.webauthn.RelyingParty;
 import com.yubico.webauthn.StartRegistrationOptions;
-import com.yubico.webauthn.data.AuthenticatorAttestationResponse;
-import com.yubico.webauthn.data.AuthenticatorSelectionCriteria;
-import com.yubico.webauthn.data.ByteArray;
-import com.yubico.webauthn.data.ClientRegistrationExtensionOutputs;
-import com.yubico.webauthn.data.PublicKeyCredential;
-import com.yubico.webauthn.data.PublicKeyCredentialCreationOptions;
-import com.yubico.webauthn.data.ResidentKeyRequirement;
-import com.yubico.webauthn.data.UserIdentity;
+import com.yubico.webauthn.data.*;
 import com.yubico.webauthn.exception.RegistrationFailedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +22,7 @@ public class PasskeyRegistrationUseCase {
     private final PasskeyRepository passkeyRepository;
     private final RelyingParty relyingParty;
     private final HandleGenerator handleGenerator;
+    private final PersonalInfoAgreeRepository personalInfoAgreeRepository;
 
     public PasskeyRegistrationResult start(String email) {
         EmailValidator.validateEmailAddress(email);
@@ -61,19 +56,24 @@ public class PasskeyRegistrationUseCase {
     }
 
     PasskeyRegistrationResult finishInternal(PublicKeyCredentialCreationOptions options,
-                                            PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential,
-                                            String email) {
+                                             PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential,
+                                             String email) {
         try {
             relyingParty.finishRegistration(FinishRegistrationOptions.builder()
                     .request(options)
                     .response(credential)
                     .build()
             );
+            savePersonalInfoAgree(email);
             saveCredential(options, credential, email);
         } catch (RegistrationFailedException e) {
             return PasskeyRegistrationResult.failure("패스키 등록에 실패했습니다.");
         }
         return PasskeyRegistrationResult.success();
+    }
+
+    private void savePersonalInfoAgree(String email) {
+        personalInfoAgreeRepository.save(email, true);
     }
 
     private void saveCredential(PublicKeyCredentialCreationOptions options,

--- a/src/main/java/com/sign/application/usecase/PasskeyRegistrationUseCase.java
+++ b/src/main/java/com/sign/application/usecase/PasskeyRegistrationUseCase.java
@@ -3,6 +3,7 @@ package com.sign.application.usecase;
 import com.sign.application.repository.HandleGenerator;
 import com.sign.application.repository.PasskeyRepository;
 import com.sign.domain.EmailValidator;
+import com.sign.dto.PasskeyRegistrationRequest;
 import com.sign.dto.PasskeyRegistrationResult;
 import com.yubico.webauthn.FinishRegistrationOptions;
 import com.yubico.webauthn.RegisteredCredential;
@@ -50,6 +51,16 @@ public class PasskeyRegistrationUseCase {
     }
 
     public PasskeyRegistrationResult finish(PublicKeyCredentialCreationOptions options,
+                                            PasskeyRegistrationRequest registrationRequest,
+                                            String email) {
+        if (registrationRequest == null || !registrationRequest.agree()) {
+            return PasskeyRegistrationResult.failure("개인정보 수집 거부로 패스키 등록에 실패했습니다.");
+        }
+        PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential = registrationRequest.credential();
+        return finishInternal(options, credential, email);
+    }
+
+    PasskeyRegistrationResult finishInternal(PublicKeyCredentialCreationOptions options,
                                             PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential,
                                             String email) {
         try {

--- a/src/main/java/com/sign/controller/PasskeyController.java
+++ b/src/main/java/com/sign/controller/PasskeyController.java
@@ -7,6 +7,7 @@ import com.sign.controller.support.JWTWrapped;
 import com.sign.controller.support.JWTWrapper;
 import com.sign.dto.APIResponse;
 import com.sign.dto.PasskeyAssertionResult;
+import com.sign.dto.PasskeyRegistrationRequest;
 import com.sign.dto.PasskeyRegistrationResult;
 import com.yubico.webauthn.AssertionRequest;
 import com.yubico.webauthn.data.AuthenticatorAssertionResponse;
@@ -53,8 +54,8 @@ public class PasskeyController {
     @PostMapping("/registration")
     public APIResponse<PasskeyRegistrationResult> finishRegistration(@JWTWrapped String email,
                                                                      @JWTWrapped PublicKeyCredentialCreationOptions options,
-                                                                     @RequestBody PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential) {
-        PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, credential, email);
+                                                                     @RequestBody PasskeyRegistrationRequest registrationRequest) {
+        PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, registrationRequest, email);
         return new APIResponse<>(
                 "패스키 등록 요청 결과",
                 result

--- a/src/main/java/com/sign/dto/PasskeyRegistrationRequest.java
+++ b/src/main/java/com/sign/dto/PasskeyRegistrationRequest.java
@@ -1,0 +1,11 @@
+package com.sign.dto;
+
+import com.yubico.webauthn.data.AuthenticatorAttestationResponse;
+import com.yubico.webauthn.data.ClientRegistrationExtensionOutputs;
+import com.yubico.webauthn.data.PublicKeyCredential;
+
+public record PasskeyRegistrationRequest(
+        boolean agree,
+        PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential
+) {
+}

--- a/src/main/java/com/sign/infrastructure/jpa/PersonalInfoEntity.java
+++ b/src/main/java/com/sign/infrastructure/jpa/PersonalInfoEntity.java
@@ -1,0 +1,22 @@
+package com.sign.infrastructure.jpa;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PersonalInfoEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private boolean agree;
+}

--- a/src/main/java/com/sign/infrastructure/jpa/repository/PersonalInfoJpaRepository.java
+++ b/src/main/java/com/sign/infrastructure/jpa/repository/PersonalInfoJpaRepository.java
@@ -1,0 +1,7 @@
+package com.sign.infrastructure.jpa.repository;
+
+import com.sign.infrastructure.jpa.PersonalInfoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PersonalInfoJpaRepository extends JpaRepository<PersonalInfoEntity, Integer> {
+}

--- a/src/main/java/com/sign/infrastructure/repository/PersonalInfoAgreeRepositoryImpl.java
+++ b/src/main/java/com/sign/infrastructure/repository/PersonalInfoAgreeRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.sign.infrastructure.repository;
+
+import com.sign.application.repository.PersonalInfoAgreeRepository;
+import com.sign.infrastructure.jpa.PersonalInfoEntity;
+import com.sign.infrastructure.jpa.repository.PersonalInfoJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class PersonalInfoAgreeRepositoryImpl implements PersonalInfoAgreeRepository {
+
+    private final PersonalInfoJpaRepository jpaRepository;
+
+    @Override
+    public void save(String email, boolean agree) {
+        jpaRepository.save(PersonalInfoEntity.builder().email(email).agree(agree).build());
+    }
+}

--- a/src/test/java/com/sign/application/usecase/PasskeyAssertionUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/PasskeyAssertionUseCaseTest.java
@@ -59,7 +59,7 @@ class PasskeyAssertionUseCaseTest {
         PasskeyRegistrationResult result = passkeyRegistrationUseCase.start(email);
         PublicKeyCredential<AuthenticatorAttestationResponse,
                 ClientRegistrationExtensionOutputs> credential = container.create(result.getOptions());
-        passkeyRegistrationUseCase.finish(result.getOptions(), credential, email);
+        passkeyRegistrationUseCase.finishInternal(result.getOptions(), credential, email);
     }
 
     @Test

--- a/src/test/java/com/sign/application/usecase/PasskeyAssertionUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/PasskeyAssertionUseCaseTest.java
@@ -1,9 +1,8 @@
 package com.sign.application.usecase;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.sign.application.repository.HandleGenerator;
 import com.sign.application.repository.PasskeyRepository;
+import com.sign.application.repository.PersonalInfoAgreeRepository;
 import com.sign.dto.PasskeyAssertionResult;
 import com.sign.dto.PasskeyRegistrationResult;
 import com.sign.infrastructure.repository.HandleGeneratorImpl;
@@ -14,23 +13,21 @@ import com.yubico.webauthn.AssertionRequest;
 import com.yubico.webauthn.CredentialRepository;
 import com.yubico.webauthn.RegisteredCredential;
 import com.yubico.webauthn.RelyingParty;
-import com.yubico.webauthn.data.AuthenticatorAssertionResponse;
-import com.yubico.webauthn.data.AuthenticatorAttestationResponse;
-import com.yubico.webauthn.data.ByteArray;
-import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
-import com.yubico.webauthn.data.ClientRegistrationExtensionOutputs;
-import com.yubico.webauthn.data.PublicKeyCredential;
+import com.yubico.webauthn.data.*;
 import de.adesso.softauthn.Authenticators;
 import de.adesso.softauthn.CredentialsContainer;
 import de.adesso.softauthn.Origin;
 import de.adesso.softauthn.authenticator.WebAuthnAuthenticator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class PasskeyAssertionUseCaseTest {
 
@@ -43,6 +40,13 @@ class PasskeyAssertionUseCaseTest {
     private final PasskeyAssertionUseCase passkeyAssertionUseCase = new PasskeyAssertionUseCase(relyingParty,
             passkeyRepository);
 
+    private final PersonalInfoAgreeRepository personalInfoAgreeRepository = new PersonalInfoAgreeRepository() {
+        @Override
+        public void save(String email, boolean agree) {
+
+        }
+    };
+
     private final String email = "passkey@sign.co.kr";
     private final WebAuthnAuthenticator authenticator = Authenticators.yubikey5Nfc().build();
     private final PasskeyRegistrationUseCase passkeyRegistrationUseCase;
@@ -51,7 +55,7 @@ class PasskeyAssertionUseCaseTest {
     private final CredentialsContainer container = new CredentialsContainer(origin, List.of(authenticator));
 
     PasskeyAssertionUseCaseTest() {
-        passkeyRegistrationUseCase = new PasskeyRegistrationUseCase(passkeyRepository, relyingParty, handleGenerator);
+        passkeyRegistrationUseCase = new PasskeyRegistrationUseCase(passkeyRepository, relyingParty, handleGenerator, personalInfoAgreeRepository);
     }
 
     @BeforeEach

--- a/src/test/java/com/sign/application/usecase/PasskeyRegistrationUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/PasskeyRegistrationUseCaseTest.java
@@ -1,8 +1,5 @@
 package com.sign.application.usecase;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.sign.application.repository.HandleGenerator;
 import com.sign.application.repository.PasskeyRepository;
 import com.sign.dto.PasskeyRegistrationRequest;
@@ -14,24 +11,24 @@ import com.sign.support.fixture.RelyingPartyFixture;
 import com.yubico.webauthn.CredentialRepository;
 import com.yubico.webauthn.RegisteredCredential;
 import com.yubico.webauthn.RelyingParty;
-import com.yubico.webauthn.data.AuthenticatorAttestationResponse;
-import com.yubico.webauthn.data.ByteArray;
-import com.yubico.webauthn.data.ClientRegistrationExtensionOutputs;
-import com.yubico.webauthn.data.PublicKeyCredential;
-import com.yubico.webauthn.data.PublicKeyCredentialCreationOptions;
+import com.yubico.webauthn.data.*;
 import de.adesso.softauthn.Authenticators;
 import de.adesso.softauthn.CredentialsContainer;
 import de.adesso.softauthn.Origin;
 import de.adesso.softauthn.authenticator.WebAuthnAuthenticator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PasskeyRegistrationUseCaseTest {
 
@@ -111,46 +108,6 @@ class PasskeyRegistrationUseCaseTest {
             credential = container.create(options);
         }
 
-        @Nested
-        @DisplayName("개인정보 동의 여부 확인 테스트")
-        class Test00 {
-            @Test
-            @DisplayName("개인정보 동의를 하면 패스키를 등록한다.")
-            void test000() {
-                PasskeyRegistrationUseCase spy = Mockito.spy(passkeyRegistrationUseCase);
-                spy.finish(options, new PasskeyRegistrationRequest(true, credential), email);
-
-                Mockito.verify(spy, Mockito.times(1)).finishInternal(options, credential, email);
-            }
-            @Test
-            @DisplayName("개인정보 동의를 거부하면 패스키를 등록 안한다.")
-            void test001() {
-                PasskeyRegistrationUseCase spy = Mockito.spy(passkeyRegistrationUseCase);
-                spy.finish(options, new PasskeyRegistrationRequest(false, credential), email);
-
-                Mockito.verify(spy, Mockito.never()).finishInternal(options, credential, email);
-            }
-        }
-
-        @Test
-        @DisplayName("개인정보 동의가 되어있으면 패스키 등록이 성공한다.")
-        void test000() {
-            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, new PasskeyRegistrationRequest(true, credential), email);
-            boolean actual = result.getStatus().isSuccess();
-
-            assertThat(actual).isTrue();
-        }
-
-
-        @Test
-        @DisplayName("개인정보 동의가 되어있지 않으면 패스키 등록이 실패한다.")
-        void test0() {
-            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, new PasskeyRegistrationRequest(false, credential), email);
-            boolean actual = result.getStatus().isSuccess();
-
-            assertThat(actual).isFalse();
-        }
-
         @Test
         @DisplayName("패스키 정상 등록시 성공한다.")
         void test1() {
@@ -208,6 +165,29 @@ class PasskeyRegistrationUseCaseTest {
             boolean actual = finishResult.getStatus().isSuccess();
 
             assertThat(actual).isFalse();
+        }
+
+        @Nested
+        @DisplayName("개인정보 동의 여부 확인 테스트")
+        class Test00 {
+
+            @Test
+            @DisplayName("개인정보 동의가 되어있으면 패스키 등록이 성공한다.")
+            void test2() {
+                PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, new PasskeyRegistrationRequest(true, credential), email);
+                boolean actual = result.getStatus().isSuccess();
+
+                assertThat(actual).isTrue();
+            }
+
+            @Test
+            @DisplayName("개인정보 동의가 되어있지 않으면 패스키 등록이 실패한다.")
+            void test3() {
+                PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, new PasskeyRegistrationRequest(false, credential), email);
+                boolean actual = result.getStatus().isSuccess();
+
+                assertThat(actual).isFalse();
+            }
         }
 
         @Nested

--- a/src/test/java/com/sign/application/usecase/PasskeyRegistrationUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/PasskeyRegistrationUseCaseTest.java
@@ -2,6 +2,7 @@ package com.sign.application.usecase;
 
 import com.sign.application.repository.HandleGenerator;
 import com.sign.application.repository.PasskeyRepository;
+import com.sign.application.repository.PersonalInfoAgreeRepository;
 import com.sign.dto.PasskeyRegistrationRequest;
 import com.sign.dto.PasskeyRegistrationResult;
 import com.sign.infrastructure.repository.HandleGeneratorImpl;
@@ -35,6 +36,7 @@ class PasskeyRegistrationUseCaseTest {
     private final String email = "passkey@sign.co.kr";
     private final PasskeyRepository passkeyRepository = Mockito.mock(PasskeyRepository.class);
     private final CredentialRepository credentialRepository = Mockito.mock(CredentialRepository.class);
+    private final PersonalInfoAgreeRepository personalInfoAgreeRepository = Mockito.mock(PersonalInfoAgreeRepository.class);
 
     @Nested
     @DisplayName("Registration Value 테스트")
@@ -44,7 +46,8 @@ class PasskeyRegistrationUseCaseTest {
         private final PasskeyRegistrationUseCase passkeyRegistrationUseCase = new PasskeyRegistrationUseCase(
                 passkeyRepository,
                 relyingParty,
-                handleGenerator
+                handleGenerator,
+                personalInfoAgreeRepository
         );
 
         @Test
@@ -69,7 +72,8 @@ class PasskeyRegistrationUseCaseTest {
         private final PasskeyRegistrationUseCase passkeyRegistrationUseCase = new PasskeyRegistrationUseCase(
                 passkeyRepository,
                 relyingParty,
-                handleGenerator
+                handleGenerator,
+                personalInfoAgreeRepository
         );
 
         @Test
@@ -93,7 +97,8 @@ class PasskeyRegistrationUseCaseTest {
         private final PasskeyRegistrationUseCase passkeyRegistrationUseCase = new PasskeyRegistrationUseCase(
                 passkeyRepository,
                 relyingParty,
-                handleGenerator
+                handleGenerator,
+                personalInfoAgreeRepository
         );
         private final WebAuthnAuthenticator authenticator = Authenticators.yubikey5Nfc().build();
         private final Origin origin = new Origin("https", "sign.co.kr", -1, null);

--- a/src/test/java/com/sign/application/usecase/PasskeyRegistrationUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/PasskeyRegistrationUseCaseTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sign.application.repository.HandleGenerator;
 import com.sign.application.repository.PasskeyRepository;
+import com.sign.dto.PasskeyRegistrationRequest;
 import com.sign.dto.PasskeyRegistrationResult;
 import com.sign.infrastructure.repository.HandleGeneratorImpl;
 import com.sign.infrastructure.repository.InMemoryPasskeyRepository;
@@ -110,10 +111,50 @@ class PasskeyRegistrationUseCaseTest {
             credential = container.create(options);
         }
 
+        @Nested
+        @DisplayName("개인정보 동의 여부 확인 테스트")
+        class Test00 {
+            @Test
+            @DisplayName("개인정보 동의를 하면 패스키를 등록한다.")
+            void test000() {
+                PasskeyRegistrationUseCase spy = Mockito.spy(passkeyRegistrationUseCase);
+                spy.finish(options, new PasskeyRegistrationRequest(true, credential), email);
+
+                Mockito.verify(spy, Mockito.times(1)).finishInternal(options, credential, email);
+            }
+            @Test
+            @DisplayName("개인정보 동의를 거부하면 패스키를 등록 안한다.")
+            void test001() {
+                PasskeyRegistrationUseCase spy = Mockito.spy(passkeyRegistrationUseCase);
+                spy.finish(options, new PasskeyRegistrationRequest(false, credential), email);
+
+                Mockito.verify(spy, Mockito.never()).finishInternal(options, credential, email);
+            }
+        }
+
+        @Test
+        @DisplayName("개인정보 동의가 되어있으면 패스키 등록이 성공한다.")
+        void test000() {
+            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, new PasskeyRegistrationRequest(true, credential), email);
+            boolean actual = result.getStatus().isSuccess();
+
+            assertThat(actual).isTrue();
+        }
+
+
+        @Test
+        @DisplayName("개인정보 동의가 되어있지 않으면 패스키 등록이 실패한다.")
+        void test0() {
+            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, new PasskeyRegistrationRequest(false, credential), email);
+            boolean actual = result.getStatus().isSuccess();
+
+            assertThat(actual).isFalse();
+        }
+
         @Test
         @DisplayName("패스키 정상 등록시 성공한다.")
         void test1() {
-            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, credential, email);
+            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finishInternal(options, credential, email);
             boolean actual = result.getStatus().isSuccess();
 
             assertThat(actual).isTrue();
@@ -122,7 +163,7 @@ class PasskeyRegistrationUseCaseTest {
         @Test
         @DisplayName("해당 이메일의 패스키가 저장된다.")
         void test2() {
-            passkeyRegistrationUseCase.finish(options, credential, email);
+            passkeyRegistrationUseCase.finishInternal(options, credential, email);
             Optional<ByteArray> credential = passkeyRepository.findUserHandleByEmail(email);
             boolean actual = credential.isPresent();
 
@@ -132,9 +173,9 @@ class PasskeyRegistrationUseCaseTest {
         @Test
         @DisplayName("패스키를 중복으로 저장할 경우 실패한다.")
         void test3() {
-            passkeyRegistrationUseCase.finish(options, credential, email);
+            passkeyRegistrationUseCase.finishInternal(options, credential, email);
 
-            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, credential, email);
+            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finishInternal(options, credential, email);
             boolean actual = result.getFailReason().isEmpty();
 
             assertThat(actual).isFalse();
@@ -148,7 +189,7 @@ class PasskeyRegistrationUseCaseTest {
             PublicKeyCredential<AuthenticatorAttestationResponse,
                     ClientRegistrationExtensionOutputs> otherCredential = container.create(otherOption);
 
-            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(otherOption, otherCredential, email);
+            PasskeyRegistrationResult result = passkeyRegistrationUseCase.finishInternal(otherOption, otherCredential, email);
             boolean actual = result.getStatus().isSuccess();
 
             assertThat(actual).isTrue();
@@ -163,7 +204,7 @@ class PasskeyRegistrationUseCaseTest {
             options = startResult.getOptions();
             credential = container.create(options);
 
-            PasskeyRegistrationResult finishResult = passkeyRegistrationUseCase.finish(options, credential, email);
+            PasskeyRegistrationResult finishResult = passkeyRegistrationUseCase.finishInternal(options, credential, email);
             boolean actual = finishResult.getStatus().isSuccess();
 
             assertThat(actual).isFalse();
@@ -184,7 +225,7 @@ class PasskeyRegistrationUseCaseTest {
             @Test
             @DisplayName("전혀 다른 challenge로 패스키를 등록할 경우 예외가 발생한다.")
             void test1() {
-                PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(otherOptions, credential, email);
+                PasskeyRegistrationResult result = passkeyRegistrationUseCase.finishInternal(otherOptions, credential, email);
                 boolean actual = result.getStatus().isSuccess();
 
                 assertThat(actual).isFalse();
@@ -196,7 +237,7 @@ class PasskeyRegistrationUseCaseTest {
                 PublicKeyCredential<AuthenticatorAttestationResponse,
                         ClientRegistrationExtensionOutputs> otherCredential = container.create(otherOptions);
 
-                PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, otherCredential, email);
+                PasskeyRegistrationResult result = passkeyRegistrationUseCase.finishInternal(options, otherCredential, email);
                 boolean actual = result.getStatus().isSuccess();
 
                 assertThat(actual).isFalse();


### PR DESCRIPTION
## 📌 이슈

#35

## ✨변경 내용

- 패스키 등록 단계에서 개인정보 수집 동의를 검사한다.

## 🔎 리뷰 요청 내용

- 기존 테스트 케이스 수정을 최소화 하기 위해 코드 호출 구조를 감싸는 방식으로 구현했습니다. 적절한지 확인해주세요.

## 📚 참고 사항

- 근데 애초에 처음 이메일 입력할 때 동의해야 하는거 아닌가요?