### PR TITLE
feat: 개발자 회원 가입 API 추가

### DIFF
--- a/src/main/java/com/sign/application/repository/DeveloperRepository.java
+++ b/src/main/java/com/sign/application/repository/DeveloperRepository.java
@@ -1,0 +1,12 @@
+package com.sign.application.repository;
+
+import com.sign.domain.Developer;
+
+import java.util.Optional;
+
+public interface DeveloperRepository {
+
+    Optional<Developer> saveDeveloper(Developer developer);
+
+    Optional<Developer> findDeveloperByEmail(String email);
+}

--- a/src/main/java/com/sign/application/service/DeveloperService.java
+++ b/src/main/java/com/sign/application/service/DeveloperService.java
@@ -1,0 +1,30 @@
+package com.sign.application.service;
+
+import com.sign.application.usecase.DeveloperUseCase;
+import com.sign.application.usecase.PasskeyRegistrationUseCase;
+import com.sign.dto.PasskeyRegistrationResult;
+import com.yubico.webauthn.data.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeveloperService {
+    private final DeveloperUseCase developerUseCase;
+    private final PasskeyRegistrationUseCase passkeyRegistrationUseCase;
+
+    public PasskeyRegistrationResult start(String email) {
+        return passkeyRegistrationUseCase.start(email);
+    }
+
+    public PasskeyRegistrationResult finish(PublicKeyCredentialCreationOptions options,
+                                            PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential,
+                                            String email) {
+
+        PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, credential, email);
+        if (result.isSuccess()) {
+            developerUseCase.saveDeveloper(email);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/sign/application/usecase/DeveloperUseCase.java
+++ b/src/main/java/com/sign/application/usecase/DeveloperUseCase.java
@@ -1,0 +1,23 @@
+package com.sign.application.usecase;
+
+import com.sign.application.repository.DeveloperRepository;
+import com.sign.domain.Developer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class DeveloperUseCase {
+
+    private final DeveloperRepository developerRepository;
+
+    public Optional<Developer> saveDeveloper(String email) {
+        if (developerRepository.findDeveloperByEmail(email).isPresent()) {
+            return Optional.empty();
+        }
+
+        return developerRepository.saveDeveloper(new Developer(email));
+    }
+}

--- a/src/main/java/com/sign/controller/PasskeyController.java
+++ b/src/main/java/com/sign/controller/PasskeyController.java
@@ -1,5 +1,6 @@
 package com.sign.controller;
 
+import com.sign.application.service.DeveloperService;
 import com.sign.application.usecase.PasskeyAssertionUseCase;
 import com.sign.application.usecase.PasskeyRegistrationUseCase;
 import com.sign.controller.support.CookieManager;
@@ -9,21 +10,12 @@ import com.sign.dto.APIResponse;
 import com.sign.dto.PasskeyAssertionResult;
 import com.sign.dto.PasskeyRegistrationResult;
 import com.yubico.webauthn.AssertionRequest;
-import com.yubico.webauthn.data.AuthenticatorAssertionResponse;
-import com.yubico.webauthn.data.AuthenticatorAttestationResponse;
-import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
-import com.yubico.webauthn.data.ClientRegistrationExtensionOutputs;
-import com.yubico.webauthn.data.PublicKeyCredential;
-import com.yubico.webauthn.data.PublicKeyCredentialCreationOptions;
+import com.yubico.webauthn.data.*;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -32,6 +24,7 @@ public class PasskeyController {
 
     private final PasskeyRegistrationUseCase passkeyRegistrationUseCase;
     private final PasskeyAssertionUseCase passkeyAssertionUseCase;
+    private final DeveloperService developerService;
     private final JWTWrapper JWTWrapper;
     private final CookieManager cookieManager;
 
@@ -55,6 +48,17 @@ public class PasskeyController {
                                                                      @JWTWrapped PublicKeyCredentialCreationOptions options,
                                                                      @RequestBody PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential) {
         PasskeyRegistrationResult result = passkeyRegistrationUseCase.finish(options, credential, email);
+        return new APIResponse<>(
+                "패스키 등록 요청 결과",
+                result
+        );
+    }
+
+    @PostMapping("/registration/developer")
+    public APIResponse<PasskeyRegistrationResult> finishRegistrationDeveloper(@JWTWrapped String email,
+                                                                              @JWTWrapped PublicKeyCredentialCreationOptions options,
+                                                                              @RequestBody PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> credential) {
+        PasskeyRegistrationResult result = developerService.finish(options, credential, email);
         return new APIResponse<>(
                 "패스키 등록 요청 결과",
                 result

--- a/src/main/java/com/sign/domain/Developer.java
+++ b/src/main/java/com/sign/domain/Developer.java
@@ -1,0 +1,4 @@
+package com.sign.domain;
+
+public record Developer(String email) {
+}

--- a/src/main/java/com/sign/dto/PasskeyRegistrationResult.java
+++ b/src/main/java/com/sign/dto/PasskeyRegistrationResult.java
@@ -26,4 +26,12 @@ public class PasskeyRegistrationResult {
     public static PasskeyRegistrationResult failure(String failReason) {
         return new PasskeyRegistrationResult(Status.FAIL, null, failReason);
     }
+
+    public boolean isSuccess() {
+        return status == Status.SUCCESS;
+    }
+
+    public boolean isFailure() {
+        return status == Status.FAIL;
+    }
 }

--- a/src/main/java/com/sign/infrastructure/jpa/DeveloperEntity.java
+++ b/src/main/java/com/sign/infrastructure/jpa/DeveloperEntity.java
@@ -1,0 +1,21 @@
+package com.sign.infrastructure.jpa;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeveloperEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+}

--- a/src/main/java/com/sign/infrastructure/jpa/repository/DeveloperJpaRepository.java
+++ b/src/main/java/com/sign/infrastructure/jpa/repository/DeveloperJpaRepository.java
@@ -1,0 +1,11 @@
+package com.sign.infrastructure.jpa.repository;
+
+import com.sign.infrastructure.jpa.DeveloperEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeveloperJpaRepository extends JpaRepository<DeveloperEntity, Long> {
+
+    Optional<DeveloperEntity> findByEmail(String email);
+}

--- a/src/main/java/com/sign/infrastructure/repository/DeveloperRepositoryImpl.java
+++ b/src/main/java/com/sign/infrastructure/repository/DeveloperRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.sign.infrastructure.repository;
+
+import com.sign.application.repository.DeveloperRepository;
+import com.sign.domain.Developer;
+import com.sign.infrastructure.jpa.DeveloperEntity;
+import com.sign.infrastructure.jpa.repository.DeveloperJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class DeveloperRepositoryImpl implements DeveloperRepository {
+
+    private final DeveloperJpaRepository developerJpaRepository;
+
+    @Override
+    public Optional<Developer> saveDeveloper(Developer developer) {
+        DeveloperEntity developerEntity = DeveloperEntity.builder()
+                .email(developer.email())
+                .build();
+        developerJpaRepository.save(developerEntity);
+        return Optional.of(developer);
+    }
+
+    @Override
+    public Optional<Developer> findDeveloperByEmail(String email) {
+        return developerJpaRepository.findByEmail(email).map(it -> new Developer(it.getEmail()));
+    }
+}


### PR DESCRIPTION
## 📌 이슈

# 38

## ✨변경 내용

- 개발자 회원 가입 API 추가

## 🔎 리뷰 요청 내용

### Service 계층의 추가 괜찮은지

개발자 회원가입의 경우 일반 회원가입과 거의 같습니다. 따라서, 기존 코드를 재사용 해야 한다 생각했습니다. 그러기 위해 기존의 UseCase 와 Controller 사이에 Service 레이어를 추가해 개발자 회원가입만을 위한 로직을 추가 작성하고, 기존의 UseCase 를 재사용하도록 구현했습니다.

## 📚 참고 사항

