### PR TITLE
feat: 개발자 회원가입 로그인 구현

### DIFF
--- a/src/main/java/com/sign/application/repository/DeveloperRepository.java
+++ b/src/main/java/com/sign/application/repository/DeveloperRepository.java
@@ -1,0 +1,9 @@
+package com.sign.application.repository;
+
+import com.sign.domain.Developer;
+import java.util.Optional;
+
+public interface DeveloperRepository {
+
+    Optional<Developer> findByEmail(String email);
+}

--- a/src/main/java/com/sign/application/repository/DeveloperRepository.java
+++ b/src/main/java/com/sign/application/repository/DeveloperRepository.java
@@ -1,9 +1,12 @@
 package com.sign.application.repository;
 
 import com.sign.domain.Developer;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface DeveloperRepository {
 
     Optional<Developer> findByEmail(String email);
+
+    void save(String email, LocalDateTime agreedAt);
 }

--- a/src/main/java/com/sign/application/usecase/DeveloperLoginUseCase.java
+++ b/src/main/java/com/sign/application/usecase/DeveloperLoginUseCase.java
@@ -1,0 +1,34 @@
+package com.sign.application.usecase;
+
+import com.sign.dto.DeveloperLoginRequest;
+import com.sign.dto.DeveloperLoginResult;
+import com.sign.dto.PasskeyAssertionResult;
+import com.sign.dto.Status;
+import com.sign.infrastructure.repository.DeveloperRepositoryImpl;
+import com.yubico.webauthn.AssertionRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeveloperLoginUseCase {
+
+    private static final String FAIL_REASON = "아이디 존재하지 않거나, 인증에 실패했습니다.";
+
+    private final DeveloperRepositoryImpl repository;
+    private final PasskeyAssertionUseCase passkeyAssertionUseCase;
+
+    public DeveloperLoginResult login(AssertionRequest options, DeveloperLoginRequest request) {
+        PasskeyAssertionResult assertionResult = passkeyAssertionUseCase.finish(options, request.credential());
+        if (assertionResult.getStatus() == Status.SUCCESS) {
+            return findDeveloperByEmail(request);
+        }
+        return DeveloperLoginResult.failure(FAIL_REASON);
+    }
+
+    private DeveloperLoginResult findDeveloperByEmail(DeveloperLoginRequest request) {
+        return repository.findByEmail(request.email())
+                .map((it) -> DeveloperLoginResult.success(it.getEmail()))
+                .orElseGet(() -> DeveloperLoginResult.failure(FAIL_REASON));
+    }
+}

--- a/src/main/java/com/sign/application/usecase/DeveloperRegistrationUseCase.java
+++ b/src/main/java/com/sign/application/usecase/DeveloperRegistrationUseCase.java
@@ -1,0 +1,38 @@
+package com.sign.application.usecase;
+
+import com.sign.dto.DeveloperRegistrationRequest;
+import com.sign.dto.DeveloperRegistrationResult;
+import com.sign.dto.PasskeyAssertionResult;
+import com.sign.dto.Status;
+import com.sign.infrastructure.repository.DeveloperRepositoryImpl;
+import com.yubico.webauthn.AssertionRequest;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeveloperRegistrationUseCase {
+
+    private final DeveloperRepositoryImpl repository;
+    private final PasskeyAssertionUseCase passkeyAssertionUseCase;
+    private final Clock clock;
+
+    public DeveloperRegistrationResult registerDeveloper(AssertionRequest options,
+                                                         DeveloperRegistrationRequest request) {
+        PasskeyAssertionResult assertionResult = passkeyAssertionUseCase.finish(options, request.credential());
+        if (assertionResult.getStatus() == Status.SUCCESS) {
+            return register(request);
+        }
+        return DeveloperRegistrationResult.failure(assertionResult.getFailReason());
+    }
+
+    private DeveloperRegistrationResult register(DeveloperRegistrationRequest request) {
+        if (request.agree()) {
+            repository.save(request.email(), LocalDateTime.now(clock));
+            return DeveloperRegistrationResult.success();
+        }
+        return DeveloperRegistrationResult.failure("회원 가입에 동의하지 않았습니다.");
+    }
+}

--- a/src/main/java/com/sign/domain/Developer.java
+++ b/src/main/java/com/sign/domain/Developer.java
@@ -1,10 +1,11 @@
 package com.sign.domain;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public class Developer {
 
     private final String email;
-
 }

--- a/src/main/java/com/sign/domain/Developer.java
+++ b/src/main/java/com/sign/domain/Developer.java
@@ -1,0 +1,10 @@
+package com.sign.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Developer {
+
+    private final String email;
+
+}

--- a/src/main/java/com/sign/dto/DeveloperLoginRequest.java
+++ b/src/main/java/com/sign/dto/DeveloperLoginRequest.java
@@ -1,0 +1,9 @@
+package com.sign.dto;
+
+import com.yubico.webauthn.data.AuthenticatorAssertionResponse;
+import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
+import com.yubico.webauthn.data.PublicKeyCredential;
+
+public record DeveloperLoginRequest(String email,
+                                    PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs> credential) {
+}

--- a/src/main/java/com/sign/dto/DeveloperLoginResult.java
+++ b/src/main/java/com/sign/dto/DeveloperLoginResult.java
@@ -1,0 +1,23 @@
+package com.sign.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DeveloperLoginResult {
+
+    private final Status status;
+
+    private final String email;
+
+    private final String failReason;
+
+    public static DeveloperLoginResult success(String email) {
+        return new DeveloperLoginResult(Status.SUCCESS, email, null);
+    }
+
+    public static DeveloperLoginResult failure(String failReason) {
+        return new DeveloperLoginResult(Status.FAIL, null, failReason);
+    }
+}

--- a/src/main/java/com/sign/dto/DeveloperRegistrationRequest.java
+++ b/src/main/java/com/sign/dto/DeveloperRegistrationRequest.java
@@ -1,0 +1,11 @@
+package com.sign.dto;
+
+import com.yubico.webauthn.data.AuthenticatorAssertionResponse;
+import com.yubico.webauthn.data.ClientAssertionExtensionOutputs;
+import com.yubico.webauthn.data.PublicKeyCredential;
+
+public record DeveloperRegistrationRequest(String email,
+                                           PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs> credential,
+                                           boolean agree) {
+
+}

--- a/src/main/java/com/sign/dto/DeveloperRegistrationResult.java
+++ b/src/main/java/com/sign/dto/DeveloperRegistrationResult.java
@@ -1,0 +1,22 @@
+package com.sign.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeveloperRegistrationResult {
+
+    private final Status status;
+
+    private final String failReason;
+
+    public static DeveloperRegistrationResult success() {
+        return new DeveloperRegistrationResult(Status.SUCCESS, null);
+    }
+
+    public static DeveloperRegistrationResult failure(String failReason) {
+        return new DeveloperRegistrationResult(Status.FAIL, failReason);
+    }
+}

--- a/src/main/java/com/sign/infrastructure/jpa/DeveloperEntity.java
+++ b/src/main/java/com/sign/infrastructure/jpa/DeveloperEntity.java
@@ -1,0 +1,30 @@
+package com.sign.infrastructure.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@Table(name = "developer")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DeveloperEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String email;
+    
+}

--- a/src/main/java/com/sign/infrastructure/jpa/DeveloperEntity.java
+++ b/src/main/java/com/sign/infrastructure/jpa/DeveloperEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,5 +27,10 @@ public class DeveloperEntity {
 
     @Column(unique = true)
     private String email;
-    
+
+    private LocalDateTime agreedAt;
+
+    public DeveloperEntity(String email, LocalDateTime agreedAt) {
+        this(null, email, agreedAt);
+    }
 }

--- a/src/main/java/com/sign/infrastructure/jpa/repository/DeveloperJpaRepository.java
+++ b/src/main/java/com/sign/infrastructure/jpa/repository/DeveloperJpaRepository.java
@@ -1,0 +1,10 @@
+package com.sign.infrastructure.jpa.repository;
+
+import com.sign.infrastructure.jpa.DeveloperEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeveloperJpaRepository extends JpaRepository<DeveloperEntity, Long> {
+
+    Optional<DeveloperEntity> findByEmail(String email);
+}

--- a/src/main/java/com/sign/infrastructure/repository/DeveloperRepositoryImpl.java
+++ b/src/main/java/com/sign/infrastructure/repository/DeveloperRepositoryImpl.java
@@ -2,10 +2,13 @@ package com.sign.infrastructure.repository;
 
 import com.sign.application.repository.DeveloperRepository;
 import com.sign.domain.Developer;
+import com.sign.infrastructure.jpa.DeveloperEntity;
 import com.sign.infrastructure.jpa.repository.DeveloperJpaRepository;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,5 +20,12 @@ public class DeveloperRepositoryImpl implements DeveloperRepository {
     public Optional<Developer> findByEmail(String email) {
         return jpaRepository.findByEmail(email)
                 .map((it) -> new Developer(it.getEmail()));
+    }
+
+    @Transactional
+    @Override
+    public void save(String email, LocalDateTime agreedAt) {
+        DeveloperEntity entity = new DeveloperEntity(email, agreedAt);
+        jpaRepository.save(entity);
     }
 }

--- a/src/main/java/com/sign/infrastructure/repository/DeveloperRepositoryImpl.java
+++ b/src/main/java/com/sign/infrastructure/repository/DeveloperRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.sign.infrastructure.repository;
+
+import com.sign.application.repository.DeveloperRepository;
+import com.sign.domain.Developer;
+import com.sign.infrastructure.jpa.repository.DeveloperJpaRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DeveloperRepositoryImpl implements DeveloperRepository {
+
+    private final DeveloperJpaRepository jpaRepository;
+
+    @Override
+    public Optional<Developer> findByEmail(String email) {
+        return jpaRepository.findByEmail(email)
+                .map((it) -> new Developer(it.getEmail()));
+    }
+}

--- a/src/test/java/com/sign/application/usecase/DeveloperLoginUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/DeveloperLoginUseCaseTest.java
@@ -103,7 +103,7 @@ class DeveloperLoginUseCaseTest {
 
 
             @Test
-            @DisplayName("로그인 한 개발자 이메일을 반환한다.")
+            @DisplayName("로그인한 개발자 이메일을 반환한다.")
             void test1() {
                 String expected = "test@sign.com";
 

--- a/src/test/java/com/sign/application/usecase/DeveloperLoginUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/DeveloperLoginUseCaseTest.java
@@ -1,0 +1,117 @@
+package com.sign.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.sign.domain.Developer;
+import com.sign.dto.DeveloperLoginRequest;
+import com.sign.dto.DeveloperLoginResult;
+import com.sign.dto.PasskeyAssertionResult;
+import com.sign.dto.Status;
+import com.sign.infrastructure.repository.DeveloperRepositoryImpl;
+import com.yubico.webauthn.AssertionRequest;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DeveloperLoginUseCaseTest {
+
+    private final DeveloperRepositoryImpl repository = Mockito.mock(DeveloperRepositoryImpl.class);
+    private final PasskeyAssertionUseCase passkeyAssertionUseCase = Mockito.mock(PasskeyAssertionUseCase.class);
+    private final DeveloperLoginUseCase developerLoginUseCase;
+    private final AssertionRequest options = Mockito.mock(AssertionRequest.class);
+    private final DeveloperLoginRequest request = Mockito.mock(DeveloperLoginRequest.class);
+
+
+    DeveloperLoginUseCaseTest() {
+        developerLoginUseCase = new DeveloperLoginUseCase(repository, passkeyAssertionUseCase);
+    }
+
+    @Nested
+    @DisplayName("login 테스트")
+    class Test1 {
+
+        @Nested
+        @DisplayName("패스키 인증에 실패한다면")
+        class WhenPasskeyAssertionFailed {
+
+            @BeforeEach
+            void mock() {
+                when(passkeyAssertionUseCase.finish(any(), any()))
+                        .thenReturn(PasskeyAssertionResult.failure("패스키 인증 실패"));
+            }
+
+            @Test
+            @DisplayName("로그인 할 수 없다.")
+            void test1() {
+                Status expected = Status.FAIL;
+
+                DeveloperLoginResult result = developerLoginUseCase.login(options, request);
+                Status actual = result.getStatus();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+
+            @Test
+            @DisplayName("패스키 실패 오류를 그대로 반환하지 않는다.")
+            void test2() {
+
+                DeveloperLoginResult result = developerLoginUseCase.login(options, request);
+                String actual = result.getFailReason();
+
+                assertThat(actual).isNotEqualTo("패스키 인증 실패");
+            }
+        }
+
+        @Nested
+        @DisplayName("개발자 회원이 존재하지 않으면")
+        class WhenDeveloperNotFound {
+
+            @BeforeEach
+            void mock() {
+                when(passkeyAssertionUseCase.finish(any(), any()))
+                        .thenReturn(PasskeyAssertionResult.success("test@sign.com"));
+                when(repository.findByEmail(any())).thenReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("로그인 할 수 없다.")
+            void test1() {
+                Status expected = Status.FAIL;
+
+                DeveloperLoginResult result = developerLoginUseCase.login(options, request);
+                Status actual = result.getStatus();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        @DisplayName("패스키 인증이 성공하고, 동의 한다면")
+        class WhenDeveloperFound {
+
+            @BeforeEach
+            void mock() {
+                when(passkeyAssertionUseCase.finish(any(), any()))
+                        .thenReturn(PasskeyAssertionResult.success("test@sign.com"));
+                when(repository.findByEmail(any())).thenReturn(Optional.of(new Developer("test@sign.com")));
+            }
+
+
+            @Test
+            @DisplayName("로그인 한 개발자 이메일을 반환한다.")
+            void test1() {
+                String expected = "test@sign.com";
+
+                DeveloperLoginResult result = developerLoginUseCase.login(options, request);
+                String actual = result.getEmail();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+        }
+    }
+}

--- a/src/test/java/com/sign/application/usecase/DeveloperRegistrationUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/DeveloperRegistrationUseCaseTest.java
@@ -43,7 +43,7 @@ class DeveloperRegistrationUseCaseTest {
     class Test1 {
 
         @Nested
-        @DisplayName("패스키  실패한다면")
+        @DisplayName("패스키 인증에 실패한다면")
         class WhenPasskeyAssertionFailed {
 
             @BeforeEach

--- a/src/test/java/com/sign/application/usecase/DeveloperRegistrationUseCaseTest.java
+++ b/src/test/java/com/sign/application/usecase/DeveloperRegistrationUseCaseTest.java
@@ -1,0 +1,116 @@
+package com.sign.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sign.dto.DeveloperRegistrationRequest;
+import com.sign.dto.DeveloperRegistrationResult;
+import com.sign.dto.PasskeyAssertionResult;
+import com.sign.dto.Status;
+import com.sign.infrastructure.repository.DeveloperRepositoryImpl;
+import com.yubico.webauthn.AssertionRequest;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DeveloperRegistrationUseCaseTest {
+
+    private static final Clock CLOCK = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+    private static final LocalDateTime NOW = LocalDateTime.now(CLOCK);
+
+    private final DeveloperRepositoryImpl repository = Mockito.mock(DeveloperRepositoryImpl.class);
+    private final PasskeyAssertionUseCase passkeyAssertionUseCase = Mockito.mock(PasskeyAssertionUseCase.class);
+    private final DeveloperRegistrationUseCase developerRegistrationUseCase;
+    private final AssertionRequest options = Mockito.mock(AssertionRequest.class);
+    private final DeveloperRegistrationRequest request = Mockito.mock(DeveloperRegistrationRequest.class);
+
+
+    DeveloperRegistrationUseCaseTest() {
+        developerRegistrationUseCase = new DeveloperRegistrationUseCase(repository, passkeyAssertionUseCase, CLOCK);
+    }
+
+    @Nested
+    @DisplayName("registerDeveloper 테스트")
+    class Test1 {
+
+        @Nested
+        @DisplayName("패스키  실패한다면")
+        class WhenPasskeyAssertionFailed {
+
+            @BeforeEach
+            void mock() {
+                when(passkeyAssertionUseCase.finish(any(), any()))
+                        .thenReturn(PasskeyAssertionResult.failure("패스키 인증 실패"));
+            }
+
+            @Test
+            @DisplayName("개발자 가입을 진행할 수 없다.")
+            void test1() {
+                Status expected = Status.FAIL;
+
+                DeveloperRegistrationResult result = developerRegistrationUseCase.registerDeveloper(
+                        options, request);
+                Status actual = result.getStatus();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        @DisplayName("동의를 하지 않으면")
+        class WhenNotAgree {
+
+            @BeforeEach
+            void mock() {
+                when(passkeyAssertionUseCase.finish(any(), any()))
+                        .thenReturn(PasskeyAssertionResult.success("test@sign.com"));
+                when(request.agree()).thenReturn(false);
+            }
+
+            @Test
+            @DisplayName("개발자 가입을 진행할 수 없다.")
+            void test1() {
+                Status expected = Status.FAIL;
+
+                DeveloperRegistrationResult result = developerRegistrationUseCase.registerDeveloper(
+                        options, request);
+                Status actual = result.getStatus();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        @DisplayName("패스키 인증이 성공하고, 동의 한다면")
+        class WhenAgree {
+
+            @BeforeEach
+            void mock() {
+                when(passkeyAssertionUseCase.finish(any(), any()))
+                        .thenReturn(PasskeyAssertionResult.success("test@sign.com"));
+                when(request.agree()).thenReturn(true);
+                when(request.email()).thenReturn("test@sign.com");
+                developerRegistrationUseCase.registerDeveloper(options, request);
+            }
+
+
+            @Test
+            @DisplayName("데이터베이스에 개발자 회원과 동의 날짜가 저장된다.")
+            void test2() {
+                verify(repository).save(
+                        eq("test@sign.com"),
+                        eq(LocalDateTime.now(CLOCK))
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 이슈

- #38 

## ✨변경 내용

개발자 회원 가입 및 로그인을 구현했습니다. 

## 🔎 리뷰 요청 내용

패스키UseCase를 재활용해서 로그인 및 회원가입을 구현했는데 flow가 자연스러운지 검토 부탁드려요 

## 📚 참고 사항

앱 CRUD는 해당 브랜치를 베이스로 이어서 작업하겠습니다!
